### PR TITLE
Fix: Ensure Prolog queries end with a period and handle .env.example

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,25 @@ const ConfigManager = {
       return this._config;
     }
 
+    // Ensure .env file exists by copying .env.example if necessary
+    const fs = require('fs');
+    const path = require('path');
+    const envPath = path.resolve(process.cwd(), '.env');
+    const envExamplePath = path.resolve(process.cwd(), '.env.example');
+
+    if (!fs.existsSync(envPath) && fs.existsSync(envExamplePath)) {
+      try {
+        fs.copyFileSync(envExamplePath, envPath);
+        logger.info(
+          'No .env file found. Copied .env.example to .env. Please review and update .env with your specific settings.'
+        );
+      } catch (err) {
+        logger.warn(
+          `Could not copy .env.example to .env: ${err.message}. Proceeding without .env file creation.`
+        );
+      }
+    }
+
     dotenv.config();
 
     // Determine LLM provider with new default logic

--- a/src/llmService.js
+++ b/src/llmService.js
@@ -299,7 +299,7 @@ const LlmService = {
           'An unexpected error occurred during query to Prolog translation.',
       }
     );
-    const trimmedResult = result.trim();
+    let trimmedResult = result.trim();
     if (!trimmedResult) {
       logger.error('LLM generated an empty Prolog query.', {
         internalErrorCode: 'LLM_EMPTY_PROLOG_QUERY',
@@ -311,6 +311,10 @@ const LlmService = {
         'LLM generated an empty or whitespace-only Prolog query. Cannot proceed with reasoning.',
         'LLM_EMPTY_PROLOG_QUERY_GENERATED'
       );
+    }
+    // Ensure the prolog query ends with a period.
+    if (!trimmedResult.endsWith('.')) {
+      trimmedResult += '.';
     }
     return trimmedResult;
   },


### PR DESCRIPTION
- Modified LlmService.queryToPrologAsync to append a '.' if missing from LLM output, resolving prolog syntax errors.
- Added unit tests for this specific fix.
- Installed @babel/preset-env dev dependency.
- Implemented automatic copying of .env.example to .env in ConfigManager if .env is not found, improving setup usability.