### PR TITLE
Fix: Ensure concatenated Prolog facts are asserted correctly

### DIFF
--- a/src/llmService.js
+++ b/src/llmService.js
@@ -261,9 +261,20 @@ const LlmService = {
   },
 
   async nlToRulesAsync(text, existing_facts = '', ontology_context = '') {
+    let processedText = text;
+    // If text seems to be multiple Prolog statements concatenated without newlines
+    // e.g., "fact1.fact2." or "fact1. fact2."
+    // Add newlines to help LLM parsing as per its prompt.
+    // This regex replaces periods followed by optional spaces,
+    // but only if they are NOT already followed by a newline or the end of the string,
+    // with ".[newline]".
+    if (text.includes('.') && text.split('.').length > 2) { // More than one statement
+      processedText = text.replace(/\.\s*(?![\n\r]|$)/g, '.\n');
+    }
+
     const result = await this._callLlmAsync(
       'NL_TO_RULES',
-      { existing_facts, ontology_context, text_to_translate: text },
+      { existing_facts, ontology_context, text_to_translate: processedText },
       new JsonOutputParser(),
       {
         methodName: 'nlToRulesAsync',


### PR DESCRIPTION
The LLM was failing to split a string of concatenated Prolog facts (e.g., "fact1.fact2.fact3.") into an array of individual fact strings, despite a prompt instruction to do so. This resulted in only the last fact in such a string being asserted.

This commit modifies `LlmService.nlToRulesAsync` to preprocess the input text. If the text appears to be multiple Prolog statements concatenated without newlines, it inserts newlines between them (e.g., "fact1.\nfact2.\nfact3."). This formatting helps the LLM correctly parse the input into the desired JSON array of fact strings, ensuring all facts are asserted.