### PR TITLE
Fix: Prevent socket hang-ups by improving LLM service initialization …

### DIFF
--- a/src/demo.js
+++ b/src/demo.js
@@ -177,8 +177,16 @@ async function runFamilyOntologyDemoAsync() {
     }
     try { // Attempt to delete if it exists, to ensure a clean state for the demo
       await callApi('deleteOntology', ontologyName);
-      demoLogger.cleanup(`Pre-existing ontology '${ontologyName}' deleted if it existed.`);
-    } catch (e) { /* Ignore if not found */ }
+      demoLogger.cleanup(`Attempted to delete pre-existing ontology '${ontologyName}', if it existed.`);
+    } catch (e) {
+      // Check if the error is a 404 (Not Found)
+      if (e.response && e.response.status === 404) {
+        demoLogger.info(`Info: Pre-existing ontology '${ontologyName}' not found. No deletion needed.`);
+      } else {
+        // For other errors, log them as a warning but continue, as the main goal is to load the new one.
+        demoLogger.error(`Warning: Could not delete pre-existing ontology '${ontologyName}'. Proceeding with loading.`, e.message);
+      }
+    }
 
     const loadedOntology = await callApi('addOntology', ontologyName, ontologyRules);
     demoLogger.success(`Ontology '${ontologyName}' loaded successfully!`);

--- a/src/llmProviders/anthropicProvider.js
+++ b/src/llmProviders/anthropicProvider.js
@@ -8,27 +8,29 @@ const AnthropicProvider = {
     const modelName = llmConfig.model.anthropic;
 
     if (!apiKey || apiKey.trim() === '') {
-      logger.warn(
-        'Anthropic API key (ANTHROPIC_API_KEY) not provided. Anthropic LLM service will not be available.',
-        { internalErrorCode: 'ANTHROPIC_API_KEY_MISSING' }
+      // logger.warn removed, will throw error instead
+      // { internalErrorCode: 'ANTHROPIC_API_KEY_MISSING' }
+      throw new Error(
+        'Anthropic API key (ANTHROPIC_API_KEY) not provided. Anthropic LLM service cannot be initialized.'
       );
-      return null;
     }
 
     if (!modelName || modelName.trim() === '') {
-      logger.warn(
-        'Anthropic model name (MCR_LLM_MODEL_ANTHROPIC) not configured. Service will not be available.',
-        { internalErrorCode: 'ANTHROPIC_MODEL_MISSING' }
+      // logger.warn removed, will throw error instead
+      // { internalErrorCode: 'ANTHROPIC_MODEL_MISSING' }
+      throw new Error(
+        'Anthropic model name (MCR_LLM_MODEL_ANTHROPIC) not configured. Anthropic LLM service cannot be initialized.'
       );
-      return null;
     }
 
     try {
-      return new ChatAnthropic({
+      const client = new ChatAnthropic({
         anthropicApiKey: apiKey,
         modelName,
         temperature: 0, // For consistency
       });
+      logger.info(`Anthropic provider client initialized successfully for model ${modelName}.`);
+      return client;
     } catch (error) {
       logger.error(
         `Failed to initialize Anthropic provider client: ${error.message}`,
@@ -39,7 +41,8 @@ const AnthropicProvider = {
           config: { modelName, apiKeyProvided: !!apiKey },
         }
       );
-      return null;
+      // Re-throw the error or a new specific error to be caught by LlmService.init
+      throw new Error(`Failed to initialize Anthropic provider: ${error.message}`);
     }
   },
 };

--- a/src/llmProviders/geminiProvider.js
+++ b/src/llmProviders/geminiProvider.js
@@ -6,18 +6,20 @@ const GeminiProvider = {
   initialize: (llmConfig) => {
     const { apiKey, model } = llmConfig;
     if (!apiKey.gemini) {
-      logger.warn(
-        'Gemini API key not provided. Gemini LLM service will not be available for this provider.',
-        { internalErrorCode: 'GEMINI_API_KEY_MISSING' }
+      // logger.warn removed, will throw error instead
+      // { internalErrorCode: 'GEMINI_API_KEY_MISSING' }
+      throw new Error(
+        'Gemini API key (GEMINI_API_KEY) not provided. Gemini LLM service cannot be initialized.'
       );
-      return null;
     }
     try {
-      return new ChatGoogleGenerativeAI({
+      const client = new ChatGoogleGenerativeAI({
         apiKey: apiKey.gemini,
         modelName: model.gemini,
         temperature: 0,
       });
+      logger.info(`Gemini provider client initialized successfully for model ${model.gemini}.`);
+      return client;
     } catch (error) {
       logger.error(
         `Failed to initialize Gemini provider client: ${error.message}`,
@@ -27,7 +29,8 @@ const GeminiProvider = {
           stack: error.stack,
         }
       );
-      return null;
+      // Re-throw the error or a new specific error to be caught by LlmService.init
+      throw new Error(`Failed to initialize Gemini provider: ${error.message}`);
     }
   },
 };

--- a/src/llmProviders/genericOpenaiProvider.js
+++ b/src/llmProviders/genericOpenaiProvider.js
@@ -9,19 +9,19 @@ const GenericOpenaiProvider = {
     const apiKey = llmConfig.apiKey.generic_openai; // This can be undefined
 
     if (!baseURL || baseURL.trim() === '') {
-      logger.warn(
-        'GenericOpenaiProvider: Base URL (MCR_LLM_GENERIC_OPENAI_BASE_URL) is not configured. Service will not be available.',
-        { internalErrorCode: 'GENERIC_OPENAI_BASE_URL_MISSING' }
+      // logger.warn removed, will throw error instead
+      // { internalErrorCode: 'GENERIC_OPENAI_BASE_URL_MISSING' }
+      throw new Error(
+        'GenericOpenaiProvider: Base URL (MCR_LLM_GENERIC_OPENAI_BASE_URL) is not configured. Service cannot be initialized.'
       );
-      return null;
     }
 
     if (!modelName || modelName.trim() === '') {
-      logger.warn(
-        'GenericOpenaiProvider: Model name (MCR_LLM_MODEL_GENERIC_OPENAI) is not configured. Service will not be available.',
-        { internalErrorCode: 'GENERIC_OPENAI_MODEL_MISSING' }
+      // logger.warn removed, will throw error instead
+      // { internalErrorCode: 'GENERIC_OPENAI_MODEL_MISSING' }
+      throw new Error(
+        'GenericOpenaiProvider: Model name (MCR_LLM_MODEL_GENERIC_OPENAI) is not configured. Service cannot be initialized.'
       );
-      return null;
     }
 
     try {
@@ -40,7 +40,9 @@ const GenericOpenaiProvider = {
         );
       }
 
-      return new ChatOpenAI(clientParams);
+      const client = new ChatOpenAI(clientParams);
+      logger.info(`GenericOpenaiProvider client initialized successfully for model ${modelName} at ${baseURL}.`);
+      return client;
     } catch (error) {
       logger.error(
         `Failed to initialize GenericOpenaiProvider client: ${error.message}`,
@@ -51,7 +53,8 @@ const GenericOpenaiProvider = {
           config: { modelName, baseURL, apiKeyProvided: !!apiKey },
         }
       );
-      return null;
+      // Re-throw the error or a new specific error to be caught by LlmService.init
+      throw new Error(`Failed to initialize GenericOpenaiProvider: ${error.message}`);
     }
   },
 };

--- a/src/llmProviders/openaiProvider.js
+++ b/src/llmProviders/openaiProvider.js
@@ -6,18 +6,20 @@ const OpenAiProvider = {
   initialize: (llmConfig) => {
     const { apiKey, model } = llmConfig;
     if (!apiKey.openai) {
-      logger.warn(
-        'OpenAI API key not provided. OpenAI LLM service will not be available for this provider.',
-        { internalErrorCode: 'OPENAI_API_KEY_MISSING' }
+      // logger.warn removed, will throw error instead
+      // { internalErrorCode: 'OPENAI_API_KEY_MISSING' }
+      throw new Error(
+        'OpenAI API key (OPENAI_API_KEY) not provided. OpenAI LLM service cannot be initialized.'
       );
-      return null;
     }
     try {
-      return new ChatOpenAI({
+      const client = new ChatOpenAI({
         apiKey: apiKey.openai,
         modelName: model.openai,
         temperature: 0,
       });
+      logger.info(`OpenAI provider client initialized successfully for model ${model.openai}.`);
+      return client;
     } catch (error) {
       logger.error(
         `Failed to initialize OpenAI provider client: ${error.message}`,
@@ -27,7 +29,8 @@ const OpenAiProvider = {
           stack: error.stack,
         }
       );
-      return null;
+      // Re-throw the error or a new specific error to be caught by LlmService.init
+      throw new Error(`Failed to initialize OpenAI provider: ${error.message}`);
     }
   },
 };


### PR DESCRIPTION
…and error handling.

- Enhanced LLM providers (Ollama, Gemini, OpenAI, Anthropic, GenericOpenAI) to throw errors immediately if critical configuration (API keys, reachable URLs) is missing or invalid during initialization.
- Modified LlmService.init to catch errors from provider initialization, log them clearly, and re-throw to ensure the main server fails fast if the LLM service cannot start. This prevents the server from starting with a non-functional LLM client, which previously led to 'socket hang up' errors on first use.
- Added detailed logging to LlmService._invokeChainAsync for all LLM API calls, including a unique request ID, provider info, prompt/result previews, to aid future debugging.
- Clarified logging in the family demo for ontology deletion to be more accurate, especially when an ontology is not found (404).