### PR TITLE
Fix: Address demo and chat command errors, add LLM logging

### DIFF
--- a/src/demo.js
+++ b/src/demo.js
@@ -85,6 +85,12 @@ async function runSimpleQADemoAsync() {
   let sessionId;
 
   try {
+    // Log LLM Provider Info
+    const serverStatus = await callApi('getServerStatus');
+    if (serverStatus && serverStatus.activeLlmProvider) {
+      demoLogger.info('LLM Used', `Provider: ${serverStatus.activeLlmProvider}, Model: ${serverStatus.activeLlmModel || 'N/A'}`);
+    }
+
     // 1. Create Session
     demoLogger.step('1. Creating a new reasoning session');
     const sessionData = await callApi('createSession');
@@ -167,6 +173,12 @@ async function runFamilyOntologyDemoAsync() {
   };
 
   try {
+    // Log LLM Provider Info
+    const serverStatus = await callApi('getServerStatus');
+    if (serverStatus && serverStatus.activeLlmProvider) {
+      demoLogger.info('LLM Used', `Provider: ${serverStatus.activeLlmProvider}, Model: ${serverStatus.activeLlmModel || 'N/A'}`);
+    }
+
     // 1. Load Ontology
     demoLogger.step(`1. Loading '${ontologyName}' ontology from '${ontologyFilePath}'`);
     const ontologyRules = readFileContentSafe(ontologyFilePath, logFileReadError, 'Family Ontology File');

--- a/src/handlers/sessionHandlers.js
+++ b/src/handlers/sessionHandlers.js
@@ -27,12 +27,18 @@ const sessionHandlers = {
       res.status(201).json(session);
       logger.debug('res.status(201).json(session) completed');
     } catch (err) {
-      logger.error('Error in createSession handler (explicit catch)', {
-        error: err,
+      // Defensive logging for error object
+      const errDetails = {
+        message: err.message,
+        name: err.name,
         stack: err.stack,
         isApiError: err instanceof ApiError,
-        sessionObject: session,
-      });
+      };
+      if (err instanceof ApiError) {
+        errDetails.statusCode = err.statusCode;
+        errDetails.errorCode = err.errorCode;
+      }
+      logger.error('Error in createSession handler (explicit catch)', errDetails);
       next(err);
     }
   },
@@ -86,6 +92,18 @@ const sessionHandlers = {
         metadata: { success: true },
       });
     } catch (err) {
+      // Defensive logging for error object
+      const errDetails = {
+        message: err.message,
+        name: err.name,
+        stack: err.stack,
+        isApiError: err instanceof ApiError,
+      };
+      if (err instanceof ApiError) {
+        errDetails.statusCode = err.statusCode;
+        errDetails.errorCode = err.errorCode;
+      }
+      logger.error('Error in assertAsync handler (explicit catch)', errDetails);
       next(err);
     }
   },

--- a/src/llmService.js
+++ b/src/llmService.js
@@ -314,8 +314,11 @@ const LlmService = {
         errorMessage: error.message,
         errorStack: error.stack,
         errorStatus,
-        responseData,
-        cause,
+        // Defensively log responseData and cause to prevent logger crashes
+        responseDataPreview: responseData ? JSON.stringify(responseData).substring(0, 500) : 'N/A',
+        responseDataType: typeof responseData,
+        causeMessage: cause?.message || (typeof cause === 'string' ? cause : 'N/A'),
+        causeType: typeof cause,
       });
 
       let statusCode = 502;


### PR DESCRIPTION
- Fix(simpleQA): Implement defensive error logging in LlmService and sessionHandlers to prevent potential logger crashes that could lead to "socket hang up" errors when processing complex or unserializable error objects.
- Fix(chat): Resolve "Cannot access 'checkServerStatusAsync' before initialization" error in chat TUI by wrapping `checkServerStatusAsync` and `addMessage` in `React.useCallback` to ensure stable references for `useEffect` dependencies.
- Feat(demo): Add logging of the active LLM provider and model at the start of simpleQA and familyOntology demos by querying the server's root status endpoint.