### PR TITLE
Fix: Improve MCR chat tool error handling and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This combination unlocks possibilities for more robust, explainable, and sophist
 
 - **🧩 Modularity**: Structured into logical components (Config, Logger, LLM Service, Reasoner Service, API Handlers).
 - **🤖 Extensible LLM Support**: Supports multiple LLM providers (OpenAI, Gemini, Ollama, etc.), selectable via configuration. (Refer to `.env.example` for details).
+- **📚 Dynamic Lexicon Summary**: Automatically builds a lexicon of known predicates (name/arity) from asserted facts within a session. This summary is provided to the LLM during translation to improve consistency and accuracy in generating Prolog facts, rules, and queries. It helps the LLM prefer existing predicates and understand their usage.
 - **🛡️ Robust Error Handling**: Custom `ApiError` class and centralized error-handling.
 - **✅ Configuration Validation**: Checks for required API keys and settings on startup.
 - **📦 Dependency Management**: Uses `package.json` for Node.js dependencies.

--- a/src/strategies/SIRR1Strategy.js
+++ b/src/strategies/SIRR1Strategy.js
@@ -115,15 +115,16 @@ class SIRR1Strategy {
    * @throws {Error} If translation or SIR processing fails.
    */
   async assert(naturalLanguageText, llmProvider, options = {}) {
-    const { existingFacts = '', ontologyRules = '' } = options;
+    const { existingFacts = '', ontologyRules = '', lexiconSummary = 'No lexicon summary available.' } = options;
     logger.debug(
-      `[SIRR1Strategy] Asserting NL via SIR: "${naturalLanguageText}"`
+      `[SIRR1Strategy] Asserting NL via SIR: "${naturalLanguageText}". Lexicon summary: ${lexiconSummary.substring(0,100)}...`
     );
 
     const sirPromptUser = fillTemplate(prompts.NL_TO_SIR_ASSERT.user, {
       naturalLanguageText,
       existingFacts,
       ontologyRules,
+      lexiconSummary,
     });
 
     const llmJsonOutput = await llmProvider.generate(
@@ -207,9 +208,9 @@ class SIRR1Strategy {
    * @throws {Error} If translation fails or the generated query is invalid.
    */
   async query(naturalLanguageQuestion, llmProvider, options = {}) {
-    const { existingFacts = '', ontologyRules = '' } = options;
+    const { existingFacts = '', ontologyRules = '', lexiconSummary = 'No lexicon summary available.' } = options;
     logger.debug(
-      `[SIRR1Strategy] Translating NL query (direct): "${naturalLanguageQuestion}"`
+      `[SIRR1Strategy] Translating NL query (direct): "${naturalLanguageQuestion}". Lexicon summary: ${lexiconSummary.substring(0,100)}...`
     );
 
     // Using the same NL_TO_QUERY prompt as DirectS1Strategy for now.
@@ -218,6 +219,7 @@ class SIRR1Strategy {
       naturalLanguageQuestion,
       existingFacts,
       ontologyRules,
+      lexiconSummary,
     });
 
     const prologQuery = await llmProvider.generate(

--- a/tests/mcrService.test.js
+++ b/tests/mcrService.test.js
@@ -30,9 +30,12 @@ jest.mock('../src/sessionManager', () => ({
   addFacts: jest.fn(),
   createSession: jest.fn(),
   deleteSession: jest.fn(),
+  getLexiconSummary: jest.fn().mockReturnValue('lexicon_entry/1'), // Added mock for getLexiconSummary
 }));
 jest.mock('../src/ontologyService', () => ({
   listOntologies: jest.fn(),
+  // Adding a mock for getGlobalOntologyRulesAsString as it's used in mcrService
+  getGlobalOntologyRulesAsString: jest.fn().mockResolvedValue('global_ontology_rule_from_mock.'),
 }));
 jest.mock('../src/logger', () => ({
   info: jest.fn(),


### PR DESCRIPTION
This commit addresses several issues identified in the MCR interactive chat tool:

1.  **Improved Error Presentation (`chat.js`):**
    *   Parses JSON error responses from the API to display user-friendly messages.
    *   Provides contextual tips for common errors like "Input is not an assertable statement" and "Invalid term structure in SIR JSON."

2.  **Dynamic Lexicon Summary:**
    *   `sessionManager.js`: Now builds a lexicon (predicates/arities) for each session as facts are added.
    *   `mcrService.js`: Retrieves and passes the lexicon summary to translation strategies.
    *   `SIRR1Strategy.js`: Uses the lexicon summary in prompts.

3.  **Enhanced LLM Prompts (`prompts.js`):**
    *   `NL_TO_SIR_ASSERT` and `NL_TO_QUERY` prompts now include the lexicon summary.
    *   `NL_TO_SIR_ASSERT` has improved guidance for handling complex sentences, argument structures (must be array of strings), and negations (e.g., "software without warranty" -> `has_warranty(software, false)`).
    *   Includes examples for better query generation with specific entities.

4.  **Test Suite Maintenance:**
    *   Updated mocks in `tests/mcrService.test.js` for `sessionManager.getLexiconSummary` and added `ontologyService.getGlobalOntologyRulesAsString`.
    *   Added `getGlobalOntologyRulesAsString` to `src/ontologyService.js`.
    *   All tests are passing after these changes.

5.  **UX (`chat.js`):**
    *   Minor adjustment to potentially mitigate a repeated prompt line issue on error.

6.  **Documentation (`README.md`):**
    *   Added a description of the new Dynamic Lexicon Summary feature.