### PR TITLE
Fix: Ensure assert API calls use 'text' property in payload

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -73,7 +73,9 @@ class Example {
 
     try {
       const axios = (await import('axios')).default;
-      const payload = isProlog ? { prolog: fact } : { text: fact };
+      // Always use the 'text' property for the fact, regardless of type.
+      // The 'type' or 'isProlog' can be used for logging or other client-side logic if needed.
+      const payload = { text: fact };
       const assertResponse = await axios.post(
         `${this.apiBaseUrl}/sessions/${this.sessionId}/assert`,
         payload,


### PR DESCRIPTION
Changed Example.assertFact in demo.js to always use { text: fact } when sending data to the /sessions/:sessionId/assert endpoint. This resolves an issue where sending prolog facts with { prolog: fact } caused an API error due to the server expecting the 'text' property.